### PR TITLE
Separate updates to content from spinner animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cfg := yacspin.Config{
 	Delay:           100 * time.Millisecond,
 	CharSet:         yacspin.CharSets[59],
 	Suffix:          " backing up database to S3",
-    SuffixAutoColon: true,
+	SuffixAutoColon: true,
 	Message:         "exporting data",
 	StopCharacter:   "✓",
 	StopColors:      []string{"fgGreen"},


### PR DESCRIPTION
Prior to this, your spinner content could only be updated as often as the
spinner was rendering. Data liveliness was tied to your animation speed, which
meant for faster updates you had to sacrifice what your spinner animation looked
like.

This change separates the two, so that calling a method like `Message()` should
update the spinner's message in near realtime without the spinner itself being
animated.