### PR TITLE
Reset the buffer when constructing the spinner

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -256,8 +256,11 @@ func New(cfg Config) (*Spinner, error) {
 		cfg.NotTTY = true
 	}
 
+	buf := bytes.NewBuffer(make([]byte, 2048))
+	buf.Reset()
+
 	s := &Spinner{
-		buffer:            bytes.NewBuffer(make([]byte, 2048)),
+		buffer:            buf,
 		mu:                &sync.Mutex{},
 		frequency:         cfg.Frequency,
 		status:            uint32Ptr(0),

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -132,6 +132,10 @@ func TestNew(t *testing.T) {
 				t.Fatal("spinner is nil")
 			}
 
+			if n := spinner.buffer.Len(); n != 0 {
+				t.Fatalf("spinner.buffer.Len() = %d, want 0", n)
+			}
+
 			if spinner.colorAll != tt.cfg.ColorAll {
 				t.Fatalf("spinner.colorAll = %t, want %t", spinner.colorAll, tt.cfg.ColorAll)
 			}


### PR DESCRIPTION
This needs to be done, otherwise the buffer will print null bytes at the
beginning of the first line.