### PR TITLE
Add a test to make sure all CharSets don't cause .CharSet() errors

### DIFF
--- a/character_sets_test.go
+++ b/character_sets_test.go
@@ -1,0 +1,18 @@
+package yacspin
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestCharSets(t *testing.T) {
+	spinner, err := New(Config{Frequency: time.Second})
+	testErrCheck(t, "New()", "", err)
+
+	for i := 0; i < len(CharSets); i++ {
+		name := fmt.Sprintf("spinner.CharSet(CharSets[%d])", i)
+		err := spinner.CharSet(CharSets[i])
+		testErrCheck(t, name, "", err)
+	}
+}


### PR DESCRIPTION
These should always work out of the box, so may as well build an assertion for
it.