### PR TITLE
Fail Start() if no CharSet has been set for the spinner

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -442,6 +442,17 @@ func (s *Spinner) Start() error {
 
 	s.mu.Lock()
 
+	if len(s.chars) == 0 {
+		s.mu.Unlock()
+
+		// move us to the stopped state
+		if !atomic.CompareAndSwapUint32(s.status, statusStarting, statusStopped) {
+			panic("atomic invariant encountered")
+		}
+
+		return errors.New("before starting the spinner a CharSet must be set")
+	}
+
 	s.frequencyUpdateCh = make(chan time.Duration, 4)
 	s.dataUpdateCh, s.cancelCh = make(chan struct{}, 1), make(chan struct{}, 1)
 

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -797,6 +797,21 @@ func TestSpinner_Start(t *testing.T) {
 			err: "spinner already running or shutting down",
 		},
 		{
+			name: "empty_CharSet",
+			spinner: &Spinner{
+				buffer:          &bytes.Buffer{},
+				status:          uint32Ptr(statusStopped),
+				mu:              &sync.Mutex{},
+				frequency:       time.Millisecond,
+				colorFn:         fmt.Sprintf,
+				stopColorFn:     fmt.Sprintf,
+				stopFailColorFn: fmt.Sprintf,
+				stopMsg:         "stop msg",
+				stopFailMsg:     "stop fail msg",
+			},
+			err: "before starting the spinner a CharSet must be set",
+		},
+		{
 			name: "spinner",
 			spinner: &Spinner{
 				buffer:          &bytes.Buffer{},
@@ -808,6 +823,21 @@ func TestSpinner_Start(t *testing.T) {
 				stopFailColorFn: fmt.Sprintf,
 				stopMsg:         "stop msg",
 				stopFailMsg:     "stop fail msg",
+				maxWidth:        3,
+				chars: []character{
+					character{
+						Value: ".",
+						Size:  1,
+					},
+					character{
+						Value: "..",
+						Size:  21,
+					},
+					character{
+						Value: "...",
+						Size:  3,
+					},
+				},
 			},
 		},
 		{
@@ -823,6 +853,21 @@ func TestSpinner_Start(t *testing.T) {
 				stopMsg:         "stop msg",
 				stopFailMsg:     "stop fail msg",
 				isNotTTY:        true,
+				maxWidth:        3,
+				chars: []character{
+					character{
+						Value: ".",
+						Size:  1,
+					},
+					character{
+						Value: "..",
+						Size:  21,
+					},
+					character{
+						Value: "...",
+						Size:  3,
+					},
+				},
 			},
 		},
 	}
@@ -831,7 +876,6 @@ func TestSpinner_Start(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
 			tt.spinner.writer = buf
-			_ = tt.spinner.CharSet(CharSets[26])
 
 			err := tt.spinner.Start()
 


### PR DESCRIPTION
I believe the code will panic otherwise. No use causing that sort of behavior
for consumers if we do know they've provided an invalid configuration.