### PR TITLE
Add TerminalMode config; make Frequency optional when not TTY

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,18 +110,26 @@ want to change a few configuration items via method calls, you can `Pause()` the
 spinner first. After making the changes you can call `Unpause()`, and it will
 continue rendering like normal with the newly applied configuration.
 
-#### Supporting non-TTY Output Targets
-`yacspin` also has native support for non-TTY output targets. This is detected
-automatically within the constructor, or can be specified via the `NotTTY`
-`Config` struct field, and results in a different mode of operation.
+#### Supporting Non-Interactive (TTY) Output Targets
+`yacspin` also has native support for non-interactive (TTY) output targets. By
+default this is detected in the constructor, or can be overriden via the
+`TerminalMode` `Config` struct field. When detecting the application is not
+running withn a TTY session, the behavior of the spinner is different.
 
-Specifically, when this is detected the spinner no longer uses colors, disables
-the automatic spinner animation, and instead only animates the spinner when updating the
-message. In addition, each animation is rendered on a new line instead of
-overwriting the current line.
+Specifically, when this is automatically detected the spinner no longer uses
+colors, disables the automatic spinner animation, and instead only animates the
+spinner when updating the message. In addition, each animation is rendered on a
+new line instead of overwriting the current line.
 
 This should result in human-readable output without any changes needed by
 consumers, even when the system is writing to a non-TTY destination.
+
+#### Manually Stepping Animation
+If you'd like to manually animate the spinner, you can do so by setting the
+`TerminalMode` to `ForceNoTTYMode | ForceSmartTerminalMode`. In this mode the
+spinner will still use colors and other text stylings, but the animation only
+happens when data is updated and on individual lines. You can accomplish this by
+calling the `Message()` method with the same used previously.
 
 ## Usage
 ```


### PR DESCRIPTION
This change introduces a substantial change to how we handle the TTY discovery
when constructing the spinner. It adds a new bitflag field to the Config struct,
TerminalMode, that allows consumers to control whether the spinner tries to
automatically disocver if it's within a TTY and/or a dumb terminal. It also
allows you to override the behaviors, if you know the automatic mode won't do
what you want.

A side effect of this change is that you can now manually step the spinner
animation by setting TerminalMode: ForceNoTTYMode, and then starting the spinner
and calling the Message() method when you want to animate the spinner. To permit
this, the Frequency field in the Config struct is now not required when calling
the New() function. An error will be generated on Start() if it's within a TTY
and the Frequency is 0.

This also deprecates the NotTTY field in the Config struct.