### PR TITLE
Make CharSets test less brittle to future changes

### DIFF
--- a/character_sets_test.go
+++ b/character_sets_test.go
@@ -10,9 +10,10 @@ func TestCharSets(t *testing.T) {
 	spinner, err := New(Config{Frequency: time.Second})
 	testErrCheck(t, "New()", "", err)
 
-	for i := 0; i < len(CharSets); i++ {
+	for i, cs := range CharSets {
 		name := fmt.Sprintf("spinner.CharSet(CharSets[%d])", i)
-		err := spinner.CharSet(CharSets[i])
+		err := spinner.CharSet(cs)
+
 		testErrCheck(t, name, "", err)
 	}
 }


### PR DESCRIPTION
When `yacspin` adds its own pre-created spinners to the `CharSets` variable,
they will start at index 500 to ideally avoid conflicts with spinners pulled-in
from github.com/briandowns/spinner. However, if that change was made today this
test would likely fail.

So let's update the test to range over the map directly, instead of using
indexes, to avoid this breaking in the future.